### PR TITLE
chore:: Dockerized version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
-FROM golang:1.21-bullseye
+FROM rust:latest
 
-# Install Rust
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-ENV PATH="$HOME/.cargo/bin:${PATH}"
+# Install Go
+RUN curl -OL https://go.dev/dl/go1.21.6.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzf go1.21.6.linux-amd64.tar.gz && \
+    rm go1.21.6.linux-amd64.tar.gz
+
+ENV PATH=$PATH:/usr/local/go/bin
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,12 @@ COPY . .
 RUN make build
 RUN ./fairyport init
 
+ARG CHAIN_RPC
+ARG CONTRACT_ADDRESS
+RUN sed -i "s|chainrpc: .*|chainrpc: ${CHAIN_RPC}|g" $HOME/.fairyport/config.yml && \
+    sed -i "s|contractaddress: .*|contractaddress: ${CONTRACT_ADDRESS}|g" $HOME/.fairyport/config.yml 
+
 EXPOSE 9090
 
 ENTRYPOINT ["./fairyport"]
-CMD ["start", "--config", "$HOME/.fairyroot/config.yml"]
+CMD ["start", "--config", "$HOME/.fairyport/config.yml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM golang:1.21-bullseye
+
+# Install Rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="$HOME/.cargo/bin:${PATH}"
+
+WORKDIR /app
+
+COPY . .
+
+RUN make build
+RUN ./fairyport init
+
+EXPOSE 9090
+
+ENTRYPOINT ["./fairyport"]
+CMD ["start", "--config", "$HOME/.fairyroot/config.yml"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,10 @@
 services:
   fairyport:
-    build: .
+    build:
+      context: .
+      args:
+      - CHAIN_RPC=fuckyou
+      - CONTRACT_ADDRESS=fuckyou
     ports:
       - "9090:9090"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  fairyport:
+    build: .
+    ports:
+      - "9090:9090"
+    volumes:
+      - .env:/app/.env
+        #- fairyport_data:/root/.fairyport
+
+        # volumes:
+        #  fairyport_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,3 @@ services:
       - "9090:9090"
     volumes:
       - .env:/app/.env
-        #- fairyport_data:/root/.fairyport
-
-        # volumes:
-        #  fairyport_data:


### PR DESCRIPTION
Added `Dockerfile` and `docker-compose.yml` files for easy local deployment.

> Usage:

```sh
docker compose up # Start `fairyblock` service
docker compose down # Stop the service
```

> Logs:

```
[+] Building 545.1s (11/11) FINISHED                                 docker:default
 => [fairyport internal] load build definition from Dockerfile                 0.0s
 => => transferring dockerfile: 422B                                           0.0s
 => [fairyport internal] load metadata for docker.io/library/rust:latest       1.2s
 => [fairyport internal] load .dockerignore                                    0.0s
 => => transferring context: 2B                                                0.0s
 => CACHED [fairyport 1/6] FROM docker.io/library/rust:latest@sha256:738ae99a  0.0s
 => [fairyport internal] load build context                                    0.0s
 => => transferring context: 5.26kB                                            0.0s
 => [fairyport 2/6] RUN curl -OL https://go.dev/dl/go1.21.6.linux-amd64.tar.  34.4s
 => [fairyport 3/6] WORKDIR /app                                               0.0s 
 => [fairyport 4/6] COPY . .                                                   0.3s 
 => [fairyport 5/6] RUN make build                                           493.1s 
 => [fairyport 6/6] RUN ./fairyport init                                       0.3s 
 => [fairyport] exporting to image                                            15.7s 
 => => exporting layers                                                       15.7s 
 => => writing image sha256:42703f649a839964e0bce28866e5e6d0a4bbc57685c4b44ac  0.0s 
 => => naming to docker.io/library/fairyport-fairyport                         0.0s 
[+] Running 2/2                                                                     
 ✔ Network fairyport_default        Created                                    0.2s 
 ✔ Container fairyport-fairyport-1  Creat...                                   0.1s 
Attaching to fairyport-1
fairyport-1  | 2025/02/06 18:12:54 Target Cosmos chain GRPC Endpoint: 127.0.0.1:9090
fairyport-1  | 2025/02/06 18:12:54 Private Key derived successfully:  13134d46f32028a7c1ad3d2d8eeaa1269acf989871a8b8bd4ea55897ea5a60c5
fairyport-1  | 2025/02/06 18:12:54 Address:  fairy1t8eh66t2w5k67kwurmn5gqhtq6d2ja0v8lg8pl
fairyport-1  | 2025/02/06 18:12:54 failed to get account: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp 127.0.0.1:9090: connect: connection refused"
fairyport-1 exited with code 1
```